### PR TITLE
Steal linuxserver's ip address

### DIFF
--- a/host_vars/daedalus.novatech-llc.com/networking.yml
+++ b/host_vars/daedalus.novatech-llc.com/networking.yml
@@ -19,3 +19,4 @@ buildbot_ip_addr:     172.16.0.110
 nexus_ip_addr:        172.16.0.111
 ddio_ip_addr:         172.16.0.112
 easyrsa_ip_addr:      172.16.0.113
+linuxserver_ip_addr:  172.16.0.4

--- a/roles/docker-buildsystem/tasks/docker_containers/server_tftp_ddio.yml
+++ b/roles/docker-buildsystem/tasks/docker_containers/server_tftp_ddio.yml
@@ -14,7 +14,7 @@
     detach: True
     image: "{{ name_prefix }}teststation_tftp_ddio_image"
     name: "{{ name_prefix }}TestStation_tftp_ddio_server"
-    ports: "{{ ddio_ip_addr }}:69:69/udp"
+    ports: "{{ linuxserver_ip_addr }}:69:69/udp"
     state: "{{ container_start_state_nondata }}"
     restart_policy: '{{ docker_restart_policy }}'
     volumes:


### PR DESCRIPTION
Simple change to take linuxserver's IP address and reconfigure the ddio tftp server to use it.