### PR TITLE
Restrict sshd configuration tasks to Daedalus

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -33,10 +33,6 @@
   become_user: root
   become_method: sudo
   roles:
-  - name: Setup SSH Daemon
-    role: sshd
-    tags:
-    - sshd
   - name: Run common Docker tasks
     role: docker-common
     tags:
@@ -49,6 +45,10 @@
   become_user: root
   become_method: sudo
   roles:
+  - name: Setup SSH Daemon
+    role: sshd
+    tags:
+    - sshd
   - name: Configure Docker networking
     role: docker-networking
     network_connection: '{{ daedalus_net_connection }}'


### PR DESCRIPTION
Daedalus is the only server currently running multiple SSH daemons where
ListenAddress is important. Using ListenAddress on some other servers
causes issues at startup if the address is not yet available. Simplest
solution is to allow those servers to continue to listen on all interfaces.